### PR TITLE
refactored

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,15 @@
 /**
  * mentions-regex <https://github.com/regexps/mentions-regex>
  *
- * Copyright (c) 2014 Charlike Mike Reagent, contributors.
+ * Copyright (c) 2014-2015 Charlike Mike Reagent, contributors.
  * Released under the MIT license.
  */
 
 'use strict';
 
-/**
- * The correct mention(s) regex. Regex done right!
- *
- * @param  {Object} `options`
- * @return {RegExp}
- */
-module.exports =  function metntionsRegex(options) {
-  options = options || {};
-
-  var startSpace = options.startSpace === false ? '' : '\\s+';
-  var endSpace = options.endSpace === false ? '' : '\\s+';
-  var length = '{1,' + (options.length || 30) + '}';
-  var match = options.match || '\\w' + length;
-
-  match = options.dot && !options.match ? '[A-Za-z0-9_.]' + length : match
-
-  return new RegExp(startSpace + '@(' + match + ')' + endSpace, options.flags);
+module.exports = function mentionsRegex(nodot) {
+  if (nodot) {
+    return /(?:^|[^＠@*!%$&#0-9A-Za-z_])[＠@](?!(?!\.))([0-9A-Za-z_]{1,15})/;
+  }
+  return /(?:^|[^＠@*!%$&#0-9A-Za-z_])[＠@]([0-9A-Za-z_\.]{1,15})/;
 };

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "mentions-regex",
   "version": "1.0.1",
-  "description": "The correct mention(s) regex. Regular expression for twitter, facebook, github, etc user mentions",
+  "description": "Regular expression for matching `@mentions`, as used on twitter, facebook, github, etc.",
   "scripts": {
     "lint": "jshint . && jscs . --reporter inline",
     "test": "mocha -r should"
   },
   "author": {
-    "name": "Charlike Make Reagent",
+    "name": "Charlike Mike Reagent",
     "email": "mameto_100@mail.bg",
     "url": "https://github.com/tunnckoCore"
   },
@@ -15,24 +15,6 @@
     "type": "git",
     "url": "git://github.com/regexps/mentions-regex.git"
   },
-  "keywords": [
-    "correct",
-    "etc",
-    "expression",
-    "facebook",
-    "github",
-    "google",
-    "mention",
-    "mentions",
-    "regex",
-    "regexp",
-    "regexps",
-    "regular",
-    "regular expression",
-    "regular expressions",
-    "twitter",
-    "user"
-  ],
   "license": {
     "type": "MIT",
     "url": "https://github.com/regexps/mentions-regex/blob/master/license.md"
@@ -41,5 +23,17 @@
   "devDependencies": {
     "mocha": "^2.0.1",
     "should": "^4.4.1"
-  }
+  },
+  "keywords": [
+    "facebook",
+    "github",
+    "google",
+    "mention",
+    "mentions",
+    "regex",
+    "regexp",
+    "regexps",
+    "regular expression",
+    "twitter"
+  ]
 }

--- a/readme.md
+++ b/readme.md
@@ -1,73 +1,41 @@
 ## [![npm versi][npmjs-img]][npmjs-url] [![mit license][license-img]][license-url] [![build status][travis-img]][travis-url] [![deps status][daviddm-img]][daviddm-url] [![regexps org][regexps-img]][regexps-url] 
 
-> The correct mention(s) regex. Regular expression for twitter, facebook, github, etc user mentions
+> Regular expression for matching `@mentions`, as used on twitter, facebook, github, etc.
 
 ## Install
+
 ```bash
-$ npm install mentions-regex
-$ npm test
+$ npm i mentions-regex && npm test
 ```
 
 
-## [.metntionsRegex](index.js#L16)
-> Default regex is `\s+@(\w{1,30})\s+`
-
-* `[options]` **{Object}**
-  - `startSpace` **{Boolean}** if `false`, will remove starting `\s+` from regex
-  - `endSpace` **{Boolean}** if `false`, will remove ending `\s+` from regex
-  - `length` **{Number}** maximum length of mention, default `30`
-  - `match` **{String}** what to match, default is `\w{1,30}`
-  - `flags` **{String}** every valid RegExp flag, default `undefined`
-  - `dot` **{Boolean}** will use `[A-Za-z0-9_.]` instead of `\w`
-* `return` **{RegExp}**
-
-
 ## Usage
-> For more use-cases see [tests](./test.js)
+
+For more use-cases see the [tests](./test.js)
 
 ```js
-var mentionsRegex = require('mentions-regex');
+var regex = require('mentions-regex');
 
-mentionsRegex().test('github @tunnckoCore')
-//=> false
-
-mentionsRegex({flags: 'g'}).test('github @tunnckoCore')
-//=> false
-
-mentionsRegex({endSpace: false}).test('github @tunnckoCore')
+regex().test('github @tunnckoCore')
 //=> true
 
-var str = '@first git @tunnckoCore and @face some @al.so email@here.com glob @last'
+regex().exec('github @tunnckoCore');
+//=> [ ' @tunnckoCore', 'tunnckoCore', ... ]
+```
 
-str.match(mentionsRegex())
-//=> [' @tunnckoCore ']
 
-str.match(mentionsRegex({flags: 'g'}))
-//=> [' @tunnckoCore ', ' @face ']
+By default, dots in screen names are invalid:
 
-str.match(mentionsRegex({flags: 'g', startSpace: false}))
-//=> ['@first ', '@tunnckoCore ', '@face ']
+```js
+regex().test('@foo.bar');
+//=> false
+```
 
-str.match(mentionsRegex({flags: 'g', endSpace: false}))
-//=> [' @tunnckoCore ', ' @face ', ' @al', ' @last']
+To allow dots, pass `true`:
 
-str.match(mentionsRegex({flags: 'g', startSpace: false, endSpace: false}))
-//=> ['@first', '@tunnckoCore', '@face', '@al', '@here', '@last']
-
-str.match(mentionsRegex({length: 5}))
-//=> [' @face ']
-
-str.match(mentionsRegex({flags: 'g', dot: true}))
-//=> [' @tunnckoCore ', ' @face ', ' @al.so ']
-
-str.match(mentionsRegex({flags: 'g', dot: true, length: 5}))
-//=> [' @face ', ' @al.so ']
-
-str.match(mentionsRegex({flags: 'g', dot: true, startSpace: false}))
-//=> ['@first ', '@tunnckoCore ', '@face ', '@al.so ', '@here.com ']
-
-str.match(mentionsRegex({flags: 'g', dot: true, startSpace: false, endSpace: false}))
-//=> ['@first', '@tunnckoCore', '@face', '@al.so', '@here.com ', '@last']
+```js
+regex(true).test('@foo.bar');
+//=> true
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -1,13 +1,45 @@
-/**
- * mentions-regex <https://github.com/tunnckoCore/mentions-regex>
+/*!
+ * mentions-regex <https://github.com/regexps/mentions-regex>
  *
- * Copyright (c) 2014 Charlike Mike Reagent, contributors.
- * Released under the MIT license.
+ * Copyright (c) 2014-2015 Charlike Mike Reagent, contributors.
+ * Licensed under the MIT license.
  */
 
 'use strict';
 
-var mentionsRegex = require('./index');
-var str = str = '@first git @tunnckoCore and @face some @al.so email@here.com glob @last'
-var res = str.match(mentionsRegex({flags: 'g', dot: true, startSpace: false, endSpace: false}))
-console.log(res)
+var assert = require('assert');
+var mentionsRegex = require('./');
+
+function match(str) {
+  return str.match(new RegExp(mentionsRegex().source, 'g'));
+}
+
+it('should match mentions in a string', function () {
+  assert.deepEqual(match('a @abc @foo xyz @baz'), [' @abc', ' @foo', ' @baz']);
+  assert.equal(mentionsRegex().exec('@abc')[1], 'abc');
+  assert.equal(mentionsRegex().exec(' @abc')[1], 'abc');
+  assert.equal(mentionsRegex().exec(' @abc ')[1], 'abc');
+  assert.equal(mentionsRegex().exec('@abc ')[1], 'abc');
+  assert.equal(mentionsRegex().exec('@abc.xyz ')[1], 'abc.xyz');
+  assert.equal(mentionsRegex().exec('@abc @foo xyz')[1], 'abc');
+  assert.equal(mentionsRegex().exec('a @abc @foo xyz')[1], 'abc');
+});
+
+it('should match mentions with a dot', function () {
+  assert.equal(mentionsRegex().test('@abc.xyz '), true);
+  assert.equal(mentionsRegex().exec('@abc.xyz ')[1], 'abc.xyz');
+});
+
+it('should not match a dot in a mention when `nodot` is true', function () {
+  assert.equal(mentionsRegex(true).test('@abc.xyz '), false);
+  assert.equal(mentionsRegex(true).exec('@abc.xyz '), null);
+});
+
+it('should not match invalid mentions', function () {
+  assert.equal(mentionsRegex().exec('abc @$foo xyz'), null);
+  assert.equal(mentionsRegex().exec('abc @!foo xyz'), null);
+  assert.equal(mentionsRegex().exec('abc @#foo xyz'), null);
+  assert.equal(mentionsRegex().exec('abc @\\foo xyz'), null);
+  assert.equal(mentionsRegex().exec('@ abc@foo xyz'), null);
+  assert.equal(mentionsRegex().exec('@@abc@foo xyz'), null);
+});

--- a/test.js
+++ b/test.js
@@ -25,6 +25,11 @@ it('should match mentions in a string', function () {
   assert.equal(mentionsRegex().exec('a @abc @foo xyz')[1], 'abc');
 });
 
+it('should not match email addresses', function () {
+  assert.equal(mentionsRegex().exec('a someone@abc.email.com'), null);
+  assert.equal(mentionsRegex().exec('a someone@abc.email.com @foo xyz')[1], 'foo');
+});
+
 it('should match mentions with a dot', function () {
   assert.equal(mentionsRegex().test('@abc.xyz '), true);
   assert.equal(mentionsRegex().exec('@abc.xyz ')[1], 'abc.xyz');


### PR DESCRIPTION
- simplified, removes options except for dot
- doesn't call `RegExp` constructor to avoid runtime compilation, much faster
- adds unit tests
